### PR TITLE
Fix Firebase deploy: add firebase.json, pass credentials to deploy step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,5 +34,11 @@ jobs:
 
       - name: Deploy to Firebase Hosting
         run: |
-          yarn global add firebase-tools
-          firebase deploy --only hosting
+          if [ -n "$FIREBASE_PROJECT" ]; then
+            npx firebase-tools deploy --only hosting --non-interactive --project "$FIREBASE_PROJECT"
+          else
+            npx firebase-tools deploy --only hosting --non-interactive
+          fi
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.home }}/firebase-service-account.json
+          FIREBASE_PROJECT: ${{ secrets.FIREBASE_PROJECT }}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,16 @@
+{
+  "hosting": {
+    "public": "dist",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- Add firebase.json with hosting public=dist and SPA rewrites
- Use npx firebase-tools and --non-interactive in CI
- Set GOOGLE_APPLICATION_CREDENTIALS on deploy step so auth is available
- Optional FIREBASE_PROJECT secret for explicit project selection